### PR TITLE
Increase the lighten() value on dark theme project cards

### DIFF
--- a/gatsby-theme-intro/tailwind.config.js
+++ b/gatsby-theme-intro/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = theme => {
         colors: {
           ...colors,
           "back-light": color(colors.back)
-            .lighten(0.18)
+            .lighten(0.40)
             .hex(),
         },
         borderRadius: {


### PR DESCRIPTION
I noticed that the project section's accent colors (outline around tags and icons) are difficult to see on the dark themes. Comparing against the screenshots the background of the project cards is significantly darker than what is shown. I think the screenshots use a value of `0.80` but I chose `0.50` for improved the contrast between the background and text.

### Before:
<img width="867" alt="Screen Shot 2022-03-26 at 7 52 36 PM" src="https://user-images.githubusercontent.com/8951682/160262419-4aa554b0-fe95-4091-9057-8f27fde24237.png">


### After: 
<img width="836" alt="Screen Shot 2022-03-26 at 7 53 42 PM" src="https://user-images.githubusercontent.com/8951682/160262425-ee4aac18-b0da-4897-99e3-57e334eb3486.png">