### PR TITLE
Refactor project icons to be extensible similar to social icons

### DIFF
--- a/gatsby-theme-intro/src/components/projects/project-icon.js
+++ b/gatsby-theme-intro/src/components/projects/project-icon.js
@@ -2,13 +2,26 @@ import React from "react"
 import { FaCompass, FaGithub } from "react-icons/fa"
 import { ProjectType } from "../../types"
 
-const ProjectIcon = ({ icon }) => (
+const ProjectIcon = ({ icon }) => {
+  const icons = {
+    github: FaGithub,
+    website: FaCompass,
+  }
+
+  const Icon = icons[icon]
+
+  return Icon ? ChosenIcon(Icon) : WebsiteIcon
+}
+
+const ChosenIcon = ( Icon ) => (
   <span className="absolute right-0 bottom-0 mb-5 mr-5 text-back">
-    {icon === "github" ? (
-      <FaGithub className="w-6 h-6" />
-    ) : (
-      <FaCompass className="w-6 h-6" />
-    )}
+    <Icon className="w-6 h-6" />
+  </span>
+)
+
+const WebsiteIcon = () => (
+  <span className="absolute right-0 bottom-0 mb-5 mr-5 text-back">
+    <FaCompass className="w-6 h-6" />
   </span>
 )
 


### PR DESCRIPTION
I am not a web developer so the existing options of `github` and `website` didn't suit my needs. I figured other developers who find this theme might desire other icons as well so I refactored the `project-icons.js` to be easier to extend as a shadow file.